### PR TITLE
Revert "fix the docker file"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN npx prisma generate
 RUN pnpm run build
 
 FROM node:22-alpine AS deployment
+
 COPY --from=builder /.output /
-COPY --from=builder /prisma /prisma
 EXPOSE 3000
 CMD ["node", "./server/index.mjs"]


### PR DESCRIPTION
This reverts commit 4ec31a1e3b6b76d3cc6efd3dfc5844be1338651a. We are completely migrating to prisma 7. This is no longer needed.