### PR TITLE
removed expenditures in schema

### DIFF
--- a/prisma/migrations/20260328201652_pnpm_prisma_generate/migration.sql
+++ b/prisma/migrations/20260328201652_pnpm_prisma_generate/migration.sql
@@ -1,0 +1,10 @@
+/*
+  Warnings:
+
+  - You are about to drop the `Expenditure` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropTable
+PRAGMA foreign_keys=off;
+DROP TABLE "Expenditure";
+PRAGMA foreign_keys=on;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,7 +30,6 @@ model User {
   donors        Donor[]
   grants        Grant[]
   grantors      Grantor[]
-  expenditures  Expenditure[]
 
   @@unique([email])
   @@map("user")
@@ -151,17 +150,4 @@ model Grant {
   proposedDate      DateTime?
   receivedDate      DateTime?
   lastEditDate      DateTime?
-}
-
-model Expenditure {
-  id                String    @id @default(cuid())
-  boardMemberId     String?
-  boardMember       User?     @relation(fields: [boardMemberId], references: [id], onDelete: Restrict)
-  purpose           String?
-  method            String?
-  monetaryAmount    String?
-  nonMonetaryAmount String?
-  notes             String?
-  spentDate         DateTime?
-  lastEditDate      DateTime
 }


### PR DESCRIPTION
Client said they don't want to track expenses anymore. Deleted the Expenditure model in the schema and all references to it to declutter the schema. Can use this branch for future generic schema clean-up as well!