### PR TITLE
redo basic responsiveness for forms and tables

### DIFF
--- a/components/Forms/DonationForm.vue
+++ b/components/Forms/DonationForm.vue
@@ -1,12 +1,12 @@
 <template>
-    <div class="bg-[#e5e9ec] p-0 gap-0 border-0 rounded-md">
-        <VeeForm :initial-values="initValues" :validation-schema="schema" class= "w-[800px] max-h-[130vh] overflow-y-auto mx-4" @submit="submitDonation">
-            <div class = "flex flex-col gap-2 sm:text-left px-6 pt-6 pb-4 space-y-0">
+    <div class="bg-[#e5e9ec] rounded-md p-6">
+        <VeeForm :initial-values="initValues" :validation-schema="schema" class= "w-full max-w-3xl max-h-[80vh] overflow-y-auto mx-auto" @submit="submitDonation">
+            <div class = "px-6 pt-6 pb-5">
               <h1 class = "form-title"> Donation Information</h1>
             </div>
             <VeeField hidden name="id"></VeeField>
             <VeeField  hidden name="index"></VeeField> 
-            <div  class="grid grid-cols-2 gap-4 mb-5">
+            <div  class="grid grid-cols-2 gap-6 px-6 mb-5">
                 <h2 class="form-field-label">Donor <span class = "text-red-500">*</span></h2>
                 <h2 class="form-field-label">Event <span class = "text-red-500">*</span></h2>          
                 <VeeField autocomplete="off" v-slot="{field}" :disabled="viewOnly" name="donorName" class="form-input focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]">
@@ -32,7 +32,7 @@
                     <VeeErrorMessage class="text-red-500"  name="event" />
                 </div>                       
             </div>
-            <div class="grid grid-cols-2 gap-4 mb-5">
+            <div class="grid grid-cols-2 gap-6 px-6 mb-5">
                 <h2 class="form-field-label">Monetary amount</h2>
                 <h2 class="form-field-label">Non-Monetary Amount</h2>
                 <VeeField autocomplete="off" :disabled="viewOnly" class="form-input focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]" name="monetaryAmount"/>
@@ -44,7 +44,7 @@
                     <VeeErrorMessage class="text-red-500"  name="nonMonetaryAmount" />
                 </div>
             </div>
-            <div class="grid grid-cols-3 gap-4 mb-5">
+            <div class="grid grid-cols-3 gap-6 px-6 mb-5">
                 <h2 class="form-field-label">Method <span class = "text-red-500">*</span></h2>
                 <h2 class="form-field-label">Status<span class = "text-red-500">*</span></h2>
                 <h2 class="form-field-label">Received Date<span class = "text-red-500">*</span></h2>
@@ -75,15 +75,19 @@
                     <VeeErrorMessage class="text-red-500" name="receivedDate" />
                 </div>
             </div>
-            <h2 class="form-field-label mb-3">Notes</h2>
-            <VeeField autocomplete="off" :disabled="viewOnly" v-slot="{field}" name="notes">
-                <textarea v-bind="field" :disabled="viewOnly" class="form-field focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"></textarea>
-            </VeeField>
-            <h2 class="form-field-label mb-2">Reason</h2>
-            <VeeField autocomplete="off" :disabled="viewOnly" v-slot="{field}" name="reason">
-                <textarea v-bind="field" :disabled="viewOnly" class="form-field focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"></textarea>
-            </VeeField>
-            <div class="flex justify-center gap-4 my-3">
+            <div class="px-6 mb-5">
+                <h2 class="form-field-label mb-2">Notes</h2>
+                <VeeField autocomplete="off" :disabled="viewOnly" v-slot="{field}" name="notes">
+                    <textarea v-bind="field" :disabled="viewOnly" class="form-field focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"></textarea>
+                </VeeField>
+            </div>
+            <div class="px-6 mb-5">
+                <h2 class="form-field-label mb-2">Reason</h2>
+                <VeeField autocomplete="off" :disabled="viewOnly" v-slot="{field}" name="reason">
+                    <textarea v-bind="field" :disabled="viewOnly" class="form-field focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"></textarea>
+                </VeeField>
+            </div>
+            <div class="flex justify-center gap-4 pb-6">
                 <button class="form-button bg-gray-600 hover:bg-gray-700" @click="cancelSubmisison">Cancel</button>
                 <button v-if="!viewOnly" class ="form-button bg-blue-600 hover:bg-blue-700">Submit </button>
             </div>           

--- a/components/Forms/DonationForm.vue
+++ b/components/Forms/DonationForm.vue
@@ -6,7 +6,7 @@
             </div>
             <VeeField hidden name="id"></VeeField>
             <VeeField  hidden name="index"></VeeField> 
-            <div  class="grid grid-cols-2 gap-6 px-6 mb-2">
+            <div class="grid grid-cols-2 gap-6 px-6">
                 <h2 class="form-field-label">Donor <span class = "text-red-500">*</span></h2>
                 <h2 class="form-field-label">Event <span class = "text-red-500">*</span></h2>          
                 <VeeField autocomplete="off" v-slot="{field}" :disabled="viewOnly" name="donorName" class="form-input focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]">
@@ -26,25 +26,25 @@
                     </input>
                 </VeeField>  
                 <div>
-                    <VeeErrorMessage class="text-red-500"  name="donorName" />
+                    <VeeErrorMessage class="text-red-500 text-sm"  name="donorName" />
                 </div>
                 <div>
-                    <VeeErrorMessage class="text-red-500"  name="event" />
+                    <VeeErrorMessage class="text-red-500 text-sm"  name="event" />
                 </div>                       
             </div>
-            <div class="grid grid-cols-2 gap-6 px-6 mb-2">
+            <div class="grid grid-cols-2 gap-6 px-6">
                 <h2 class="form-field-label">Monetary amount</h2>
                 <h2 class="form-field-label">Non-Monetary Amount</h2>
                 <VeeField autocomplete="off" :disabled="viewOnly" class="form-input focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]" name="monetaryAmount"/>
                 <VeeField autocomplete="off" :disabled="viewOnly" class="form-input focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]" name="nonMonetaryAmount"/>
                 <div>
-                    <VeeErrorMessage class="text-red-500"  name="monetaryAmount" />
+                    <VeeErrorMessage class="text-red-500 text-sm"  name="monetaryAmount" />
                 </div>
                 <div>
-                    <VeeErrorMessage class="text-red-500"  name="nonMonetaryAmount" />
+                    <VeeErrorMessage class="text-red-500 text-sm"  name="nonMonetaryAmount" />
                 </div>
             </div>
-            <div class="grid grid-cols-3 gap-6 px-6 mb-2">
+            <div class="grid grid-cols-3 gap-6 px-6">
                 <h2 class="form-field-label">Method <span class = "text-red-500">*</span></h2>
                 <h2 class="form-field-label">Status<span class = "text-red-500">*</span></h2>
                 <h2 class="form-field-label">Received Date<span class = "text-red-500">*</span></h2>
@@ -66,13 +66,13 @@
                     <input id="reqDate"  autocomplete="off" :disabled="viewOnly" v-bind="field" type="date"></input>
                 </VeeField>
                 <div>
-                    <VeeErrorMessage class="text-red-500"  name="method" />
+                    <VeeErrorMessage class="text-red-500 text-sm"  name="method" />
                 </div>
                 <div>
-                    <VeeErrorMessage class="text-red-500"  name="status" />
+                    <VeeErrorMessage class="text-red-500 text-sm"  name="status" />
                 </div>
                 <div>
-                    <VeeErrorMessage class="text-red-500" name="receivedDate" />
+                    <VeeErrorMessage class="text-red-500 text-sm" name="receivedDate" />
                 </div>
             </div>
             <div class="px-6 mb-6">

--- a/components/Forms/DonationForm.vue
+++ b/components/Forms/DonationForm.vue
@@ -6,7 +6,7 @@
             </div>
             <VeeField hidden name="id"></VeeField>
             <VeeField  hidden name="index"></VeeField> 
-            <div  class="grid grid-cols-2 gap-6 px-6 mb-5">
+            <div  class="grid grid-cols-2 gap-6 px-6 mb-2">
                 <h2 class="form-field-label">Donor <span class = "text-red-500">*</span></h2>
                 <h2 class="form-field-label">Event <span class = "text-red-500">*</span></h2>          
                 <VeeField autocomplete="off" v-slot="{field}" :disabled="viewOnly" name="donorName" class="form-input focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]">
@@ -32,7 +32,7 @@
                     <VeeErrorMessage class="text-red-500"  name="event" />
                 </div>                       
             </div>
-            <div class="grid grid-cols-2 gap-6 px-6 mb-5">
+            <div class="grid grid-cols-2 gap-6 px-6 mb-2">
                 <h2 class="form-field-label">Monetary amount</h2>
                 <h2 class="form-field-label">Non-Monetary Amount</h2>
                 <VeeField autocomplete="off" :disabled="viewOnly" class="form-input focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]" name="monetaryAmount"/>
@@ -44,7 +44,7 @@
                     <VeeErrorMessage class="text-red-500"  name="nonMonetaryAmount" />
                 </div>
             </div>
-            <div class="grid grid-cols-3 gap-6 px-6 mb-5">
+            <div class="grid grid-cols-3 gap-6 px-6 mb-2">
                 <h2 class="form-field-label">Method <span class = "text-red-500">*</span></h2>
                 <h2 class="form-field-label">Status<span class = "text-red-500">*</span></h2>
                 <h2 class="form-field-label">Received Date<span class = "text-red-500">*</span></h2>
@@ -75,7 +75,7 @@
                     <VeeErrorMessage class="text-red-500" name="receivedDate" />
                 </div>
             </div>
-            <div class="px-6 mb-5">
+            <div class="px-6 mb-6">
                 <h2 class="form-field-label mb-2">Notes</h2>
                 <VeeField autocomplete="off" :disabled="viewOnly" v-slot="{field}" name="notes">
                     <textarea v-bind="field" :disabled="viewOnly" class="form-field focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"></textarea>

--- a/components/Forms/DonationsForm.vue
+++ b/components/Forms/DonationsForm.vue
@@ -10,7 +10,7 @@
     <div class="flex flex-col gap-4">
     
     <div>
-    <label class="text-sm text-slate-600">donor (name) <span class = "text-red-500">*</span></label>
+    <label class="text-sm text-slate-600">donor <span class = "text-red-500">*</span></label>
     <input v-model="donor" class="w-full mt-1 px-3 py-2 rounded-md border border-slate-300" />
     </div>
     

--- a/components/Forms/DonorForm.vue
+++ b/components/Forms/DonorForm.vue
@@ -1,17 +1,17 @@
 <template>
-    <div class="bg-[#e5e9ec] p-0 gap-0 border-0 rounded-md">
-        <VeeForm :initial-values="initValues" :validation-schema="schema" va @submit="submitDonor" class= "w-[800px] max-h-[130vh] overflow-y-auto mx-4">
-            <div class = "flex flex-col gap-2 sm:text-left px-6 pt-6 pb-4 space-y-0">
+    <div class="bg-[#e5e9ec] rounded-md p-6">
+        <VeeForm :initial-values="initValues" :validation-schema="schema" va @submit="submitDonor" class= "w-full max-w-3xl max-h-[80vh] overflow-y-auto mx-auto">
+            <div class = "px-6 pt-6 pb-5">
               <h1 class = "form-title"> Donor Information</h1>
             </div>     
             <VeeField autocomplete="off" hidden name="id"></VeeField>
             <VeeField autocomplete="off" hidden name="index"></VeeField>  
-            <div class="grid gap-4 mb-2">
+            <div class="grid gap-6 px-6 mb-4">
                 <h2 class="form-field-label">Donor <span class = "text-red-500">*</span></h2>
                 <VeeField autocomplete="off" :disabled="viewOnly" name="donorName" class="form-input focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"></VeeField>
                 <VeeErrorMessage class="text-red-500" name= "donorName" />
             </div>
-            <div class = "gap-4 mb-5">
+            <div class = "gap-4 px-6 mb-5">
                 <VeeField v-slot="{field}" name="isAuthor" type="checkbox" :value="true" :unchecked-value="false">
                         <div class="flex items-center gap-2">
                             <input
@@ -25,7 +25,7 @@
                         </div>
                 </VeeField>
             </div>
-            <div class = "grid grid-cols-3 gap-4 mb-5">
+            <div class = "grid grid-cols-3 gap-4 px-6 mb-5">
                 <h2 class = "form-field-label"> Phone </h2>
                 <h2 class = "form-field-label"> Email </h2>
                 <h2 class = "form-field-label"> Communication Preference </h2> 
@@ -41,7 +41,7 @@
                     </select>
                 </VeeField>
             </div>
-            <div class = "mt-5 grid grid-cols-3 gap-4 my-8">
+            <div class = "grid grid-cols-3 gap-4 px-6 mb-5">
                 <h2 class = "form-field-label"> Organization </h2>
                 <h2 class = "form-field-label"> Address </h2>
                 <h2 class = "form-field-label"> Web Link </h2>
@@ -56,11 +56,13 @@
                 <VeeField autocomplete="off" :disabled="viewOnly" name="address" class="form-input focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"></VeeField> 
                 <VeeField autocomplete="off" :disabled="viewOnly" name="webLink"class="form-input focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"></VeeField>
             </div>
+            <div class = "px-6 mb-6">
                 <h2 class = "form-field-label mb-3"> Notes </h2>
                 <VeeField autocomplete="off" v-slot="{field}" :disabled="viewOnly" name="notes">
                     <textarea :disabled="viewOnly" v-bind="field" class="form-field focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"></textarea>
-                </VeeField>  
-            <div class="flex justify-center gap-4 my-3">
+                </VeeField> 
+            </div>
+            <div class="flex justify-center gap-4 pb-6">
                 <button @click="cancelSubmisison()" class ="form-button bg-gray-600 hover:bg-gray-700">Cancel</button>
                 <button v-if="!viewOnly" class ="form-button bg-blue-600 hover:bg-blue-700">Submit</button>
             </div>         

--- a/components/Forms/DonorForm.vue
+++ b/components/Forms/DonorForm.vue
@@ -9,7 +9,7 @@
             <div class="grid gap-6 px-6 mb-4">
                 <h2 class="form-field-label">Donor <span class = "text-red-500">*</span></h2>
                 <VeeField autocomplete="off" :disabled="viewOnly" name="donorName" class="form-input focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"></VeeField>
-                <VeeErrorMessage class="text-red-500" name= "donorName" />
+                <VeeErrorMessage class="text-red-500 text-sm" name= "donorName" />
             </div>
             <div class = "gap-4 px-6 mb-5">
                 <VeeField v-slot="{field}" name="isAuthor" type="checkbox" :value="true" :unchecked-value="false">
@@ -29,8 +29,8 @@
                 <h2 class = "form-field-label"> Phone </h2>
                 <h2 class = "form-field-label"> Email </h2>
                 <h2 class = "form-field-label"> Communication Preference </h2> 
-                <VeeErrorMessage class="text-red-500" name="phone" />
-                <VeeErrorMessage class="text-red-500" name="email" />
+                <VeeErrorMessage class="text-red-500 text-sm" name="phone" />
+                <VeeErrorMessage class="text-red-500 text-sm" name="email" />
                 <VeeField autocomplete="off" :disabled="viewOnly" name="phone" class="form-input focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"></VeeField>
                 <VeeField autocomplete="off" :disabled="viewOnly" name="email" class="form-input focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"></VeeField>
                 <VeeField v-slot="{field}" autocomplete="off" :disabled="viewOnly" name="preferredCommunication"class="form-input focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]">

--- a/components/Forms/EmailForm.vue
+++ b/components/Forms/EmailForm.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="bg-[#e5e9ec] rounded-md p-6">
-        <VeeForm :validation-schema="groupEmailSchema" class= "w-[800px] max-h-[130vh] overflow-y-auto" @submit="groupEmail">
+        <VeeForm :validation-schema="groupEmailSchema" class= "w-full max-w-3xl max-h-[80vh] overflow-y-auto mx-auto" @submit="groupEmail">
             <div class = "flex flex-col gap-2 text-center sm:text-left px-6 pt-6 pb-4 space-y-0">
               <h1 class = "form-title"> Send Email to {{ emailList.length }} {{ props.userName }}</h1>
             </div>         
@@ -10,14 +10,14 @@
               </div>
               <div>
                 <h2 class = "form-field-label">Subject</h2>
-                <VeeErrorMessage class="text-red-500" name="Subject"/>
+                <VeeErrorMessage class="text-red-500 text-sm" name="Subject"/>
                 <VeeField autocomplete="off" v-slot="{field}" name="Subject">
                   <input autocomplete="off" v-bind="field" class="form-input"></input>
                 </VeeField>
               </div>
               <div>
                 <h2 class = "form-field-label">Message</h2>
-                <VeeErrorMessage class="text-red-500" name="Message"/>
+                <VeeErrorMessage class="text-red-500 text-sm" name="Message"/>
                 <VeeField autocomplete="off" v-slot="{field}" name="Message">
                   <textarea v-bind="field" class="form-field focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"></textarea>
                 </VeeField>

--- a/components/Forms/EmailForm.vue
+++ b/components/Forms/EmailForm.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="bg-[#e5e9ec] p-0 gap-0 border-0 rounded-md">
+    <div class="bg-[#e5e9ec] rounded-md p-6">
         <VeeForm :validation-schema="groupEmailSchema" class= "w-[800px] max-h-[130vh] overflow-y-auto" @submit="groupEmail">
             <div class = "flex flex-col gap-2 text-center sm:text-left px-6 pt-6 pb-4 space-y-0">
               <h1 class = "form-title"> Send Email to {{ emailList.length }} {{ props.userName }}</h1>

--- a/components/Forms/GrantForm.vue
+++ b/components/Forms/GrantForm.vue
@@ -6,85 +6,92 @@
             </div>
             <VeeField hidden name="id"></VeeField>
             <VeeField  hidden name="index"></VeeField> 
-            <div  class="grid grid-cols-2 gap-6 px-6 mb-2">
-                <h2 class="form-field-label">Grantor <span class = "text-red-500">*</span></h2>
-                <h2 class="form-field-label">Purpose <span class = "text-red-500">*</span></h2>                     
-                <VeeField autocomplete="off" v-slot="{field}" :disabled="viewOnly" name="grantorName" class="form-input focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]">
-                    <input :disabled="viewOnly" autocomplete="off" v-bind="field" list="grantor-list" class="w-full px-3 py-2 bg-white border border-gray-300 rounded text-[#2d3e4d] focus:outline-none focus:ring-2 focus:ring-[#5a6a77] cursor-pointer">
-                        <datalist id="grantor-list">
-                            <option></option>
-                            <option v-if="grantors.length > 0" v-for="grantor in grantors" :value="grantor.grantor.name"></option>
-                        </datalist>
-                    </input>
-                </VeeField>  
-                <VeeField autocomplete="off" :disabled="viewOnly" v-slot="{field}" name="purpose" class="form-input focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]">
-                    <input :disabled="viewOnly" autocomplete="off" v-bind="field" list="purpose-list" class="w-full px-3 py-2 bg-white border border-gray-300 rounded text-[#2d3e4d] focus:outline-none focus:ring-2 focus:ring-[#5a6a77] cursor-pointer">
-                        <datalist id="purpose-list">
-                            <option></option>
-                            <option v-if="purposes.length > 0" v-for="purpose in purposes" :value="purpose"></option>
-                        </datalist> 
-                    </input>
-                </VeeField>  
+            <div class="grid grid-cols-2 gap-6 px-6 mb-4">
                 <div>
-                    <VeeErrorMessage class="text-red-500"  name="grantorName" />
+                    <h2 class="form-field-label mb-2">Grantor <span class = "text-red-500">*</span></h2>
+                    <VeeField autocomplete="off" v-slot="{field}" :disabled="viewOnly" name="grantorName" class="form-input focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]">
+                        <input :disabled="viewOnly" autocomplete="off" v-bind="field" list="grantor-list" class="w-full px-3 py-2 bg-white border border-gray-300 rounded text-[#2d3e4d] focus:outline-none focus:ring-2 focus:ring-[#5a6a77] cursor-pointer">
+                            <datalist id="grantor-list">
+                                <option></option>
+                                <option v-if="grantors.length > 0" v-for="grantor in grantors" :value="grantor.grantor.name"></option>
+                            </datalist>
+                        </input>
+                    </VeeField>  
+                    <VeeErrorMessage class="min-h-[20px] text-red-500 text-sm" name="grantorName" />
                 </div>
+
                 <div>
-                    <VeeErrorMessage class="text-red-500"  name="purpose" />
-                </div>                     
+                    <h2 class="form-field-label mb-2">Purpose <span class = "text-red-500">*</span></h2>                     
+                    <VeeField autocomplete="off" :disabled="viewOnly" v-slot="{field}" name="purpose" class="form-input focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]">
+                        <input :disabled="viewOnly" autocomplete="off" v-bind="field" list="purpose-list" class="w-full px-3 py-2 bg-white border border-gray-300 rounded text-[#2d3e4d] focus:outline-none focus:ring-2 focus:ring-[#5a6a77] cursor-pointer">
+                            <datalist id="purpose-list">
+                                <option></option>
+                                    <option v-if="purposes.length > 0" v-for="purpose in purposes" :value="purpose"></option>
+                            </datalist> 
+                        </input>
+                    </VeeField>  
+                    <VeeErrorMessage class="min-h-[20px] text-red-500 text-sm"  name="purpose" />
+                </div>
             </div>
             
-            <div class="grid grid-cols-2 gap-6 px-6 mb-2">
-                <h2 class="form-field-label">Monetary Amount</h2>
-                <h2 class="form-field-label">Non-Monetary Amount</h2>
-                <VeeField autocomplete="off" :disabled="viewOnly" class="form-input focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]" name="monetaryAmount"/>
-                <VeeField autocomplete="off" :disabled="viewOnly" class="form-input focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]" name="nonMonetaryAmount"/>
-                <div>
-                    <VeeErrorMessage class="text-red-500"  name="monetaryAmount" />
-                </div>
-                <div>
-                    <VeeErrorMessage class="text-red-500"  name="nonMonetaryAmount" />
-                </div>
-            </div>
             <div class="grid grid-cols-2 gap-6 px-6 mb-4">
-                <h2 class="form-field-label">Method <span class = "text-red-500">*</span></h2>
-                <h2 class="form-field-label">Status<span class = "text-red-500">*</span></h2>          
-                <VeeField v-slot="{field}" autocomplete="off" :disabled="viewOnly"name="method" class="form-input focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]">
-                    <input :disabled="viewOnly" autocomplete="off" v-bind="field" list="method-list" class="w-full px-3 py-2 bg-white border border-gray-300 rounded text-[#2d3e4d] focus:outline-none focus:ring-2 focus:ring-[#5a6a77] cursor-pointer">
-                        <datalist id="method-list">
-                            <option></option>
-                            <option v-if="methods.length > 0" v-for="method in methods" :value="method"></option>
-                        </datalist>
-                    </input>
-                </VeeField>
-                <VeeField autocomplete="off" :disabled="viewOnly" v-slot="{field}" class="form-input focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]" name="status">
-                    <select :disabled="viewOnly" v-bind="field" class="w-full px-3 py-2 bg-white border border-gray-300 rounded text-[#2d3e4d] focus:outline-none focus:ring-2 focus:ring-[#5a6a77] cursor-pointer">
-                        <option :disabled="viewOnly" value = 0> Pending </option>
-                        <option :disabled="viewOnly" value = 1> Recieved </option>
-                    </select>
-                </VeeField>
                 <div>
-                    <VeeErrorMessage class="text-red-500"  name="method" />
+                    <h2 class="form-field-label mb-2">Monetary Amount</h2>
+                    <VeeField autocomplete="off" :disabled="viewOnly" class="form-input focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]" name="monetaryAmount"/>
+                    <VeeErrorMessage class="min-h-[20px] text-red-500 text-sm"  name="monetaryAmount" />
                 </div>
+
                 <div>
-                    <VeeErrorMessage class="text-red-500"  name="status" />
+                    <h2 class="form-field-label mb-2">Non-Monetary Amount</h2>
+                    <VeeField autocomplete="off" :disabled="viewOnly" class="form-input focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]" name="nonMonetaryAmount"/>
+                    <VeeErrorMessage class="min-h-[20px] text-red-500 text-sm"  name="nonMonetaryAmount" />
                 </div>
             </div>
-            <div class="grid grid-cols-2 gap-6 px-6 mb-2">
-                <h2 class="form-field-label">Proposed Date</h2>
-                <h2 class="form-field-label">Received Date<span class = "text-red-500">*</span></h2>
-                <VeeField v-slot="{field}" autocomplete="off" :disabled="viewOnly" class="form-input focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]" name="proposedDate">
-                    <input id="propDate"  autocomplete="off" :disabled="viewOnly" v-model="proposedDateRef" v-bind="field" type="date"></input>
-                </VeeField>
-                <VeeField v-slot="{field}" autocomplete="off" :disabled="viewOnly" class="form-input focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]" name="receivedDate">
-                    <input id="reqDate"  autocomplete="off" :disabled="viewOnly" v-model="recievedDateRef" v-bind="field" type="date"></input>
-                </VeeField>
+
+            <div class="grid grid-cols-2 gap-6 px-6 mb-4">
                 <div>
-                    <VeeErrorMessage class="text-red-500" name="proposedDate" />
+                    <h2 class="form-field-label mb-2">Method <span class = "text-red-500">*</span></h2>
+                    <VeeField v-slot="{field}" autocomplete="off" :disabled="viewOnly"name="method" class="form-input focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]">
+                        <input :disabled="viewOnly" autocomplete="off" v-bind="field" list="method-list" class="w-full px-3 py-2 bg-white border border-gray-300 rounded text-[#2d3e4d] focus:outline-none focus:ring-2 focus:ring-[#5a6a77] cursor-pointer">
+                            <datalist id="method-list">
+                                <option></option>
+                                <option v-if="methods.length > 0" v-for="method in methods" :value="method"></option>
+                            </datalist>
+                        </input>
+                    </VeeField>
+                    <VeeErrorMessage class="min-h-[20px] text-red-500 text-sm"  name="method" />
                 </div>
+
                 <div>
-                    <VeeErrorMessage class="text-red-500" name="recievedDate" />
+                    <h2 class="form-field-label mb-2">Status<span class = "text-red-500">*</span></h2>           
+                    <VeeField autocomplete="off" :disabled="viewOnly" v-slot="{field}" class="form-input focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]" name="status">
+                        <select :disabled="viewOnly" v-bind="field" class="w-full px-3 py-2 bg-white border border-gray-300 rounded text-[#2d3e4d] focus:outline-none focus:ring-2 focus:ring-[#5a6a77] cursor-pointer">
+                            <option :disabled="viewOnly" value = 0> Pending </option>
+                            <option :disabled="viewOnly" value = 1> Recieved </option>
+                        </select>
+                    </VeeField>
+                    <VeeErrorMessage class="min-h-[20px] text-red-500 text-sm"  name="status" />
                 </div>
             </div>
+
+            <div class="grid grid-cols-2 gap-6 px-6 mb-4">
+                <div>
+                    <h2 class="form-field-label mb-2">Proposed Date</h2>
+                    <VeeField v-slot="{field}" autocomplete="off" :disabled="viewOnly" class="form-input focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]" name="proposedDate">
+                        <input id="propDate"  autocomplete="off" :disabled="viewOnly" v-model="proposedDateRef" v-bind="field" type="date"></input>
+                    </VeeField>
+                    <VeeErrorMessage class="min-h-[20px] text-red-500 text-sm" name="proposedDate" />
+                </div>
+
+                <div>
+                    <h2 class="form-field-label mb-2">Received Date<span class = "text-red-500">*</span></h2>
+                    <VeeField v-slot="{field}" autocomplete="off" :disabled="viewOnly" class="form-input focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]" name="receivedDate">
+                        <input id="reqDate"  autocomplete="off" :disabled="viewOnly" v-model="recievedDateRef" v-bind="field" type="date"></input>
+                    </VeeField>
+                    <VeeErrorMessage class="min-h-[20px] text-red-500 text-sm" name="recievedDate" />
+                </div>
+            </div>
+            
             <div class = "gap-4 px-6 mb-5">
                 <VeeField v-slot="{field}" name="reimburse" type="checkbox" :value="true" :unchecked-value="false">
                         <div class="flex items-center gap-2">
@@ -99,12 +106,14 @@
                         </div>
                 </VeeField>
             </div>
+
             <div class="px-6 mb-6">
                 <h2 class="form-field-label mb-2">Notes</h2>
                 <VeeField autocomplete="off" :disabled="viewOnly" v-slot="{field}" name="notes">
                     <textarea v-bind="field" class="form-field focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"></textarea>
                 </VeeField>
             </div>
+
             <div class="flex justify-center gap-4 pb-6">
                 <button class="form-button bg-gray-600 hover:bg-gray-700" @click="cancelSubmisison">Cancel</button>
                 <button v-if="!viewOnly" class ="form-button bg-blue-600 hover:bg-blue-700">Submit </button>

--- a/components/Forms/GrantForm.vue
+++ b/components/Forms/GrantForm.vue
@@ -6,7 +6,7 @@
             </div>
             <VeeField hidden name="id"></VeeField>
             <VeeField  hidden name="index"></VeeField> 
-            <div  class="grid grid-cols-2 gap-6 px-6 mb-4">
+            <div  class="grid grid-cols-2 gap-6 px-6 mb-2">
                 <h2 class="form-field-label">Grantor <span class = "text-red-500">*</span></h2>
                 <h2 class="form-field-label">Purpose <span class = "text-red-500">*</span></h2>                     
                 <VeeField autocomplete="off" v-slot="{field}" :disabled="viewOnly" name="grantorName" class="form-input focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]">
@@ -33,7 +33,7 @@
                 </div>                     
             </div>
             
-            <div class="grid grid-cols-2 gap-6 px-6 mb-4">
+            <div class="grid grid-cols-2 gap-6 px-6 mb-2">
                 <h2 class="form-field-label">Monetary Amount</h2>
                 <h2 class="form-field-label">Non-Monetary Amount</h2>
                 <VeeField autocomplete="off" :disabled="viewOnly" class="form-input focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]" name="monetaryAmount"/>
@@ -69,7 +69,7 @@
                     <VeeErrorMessage class="text-red-500"  name="status" />
                 </div>
             </div>
-            <div class="grid grid-cols-2 gap-6 px-6 mb-4">
+            <div class="grid grid-cols-2 gap-6 px-6 mb-2">
                 <h2 class="form-field-label">Proposed Date</h2>
                 <h2 class="form-field-label">Received Date<span class = "text-red-500">*</span></h2>
                 <VeeField v-slot="{field}" autocomplete="off" :disabled="viewOnly" class="form-input focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]" name="proposedDate">
@@ -99,13 +99,13 @@
                         </div>
                 </VeeField>
             </div>
-            <div class="px-6 pb-6">
+            <div class="px-6 mb-6">
                 <h2 class="form-field-label mb-2">Notes</h2>
                 <VeeField autocomplete="off" :disabled="viewOnly" v-slot="{field}" name="notes">
                     <textarea v-bind="field" class="form-field focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"></textarea>
                 </VeeField>
             </div>
-            <div class="flex justify-center gap-4 my-3">
+            <div class="flex justify-center gap-4 pb-6">
                 <button class="form-button bg-gray-600 hover:bg-gray-700" @click="cancelSubmisison">Cancel</button>
                 <button v-if="!viewOnly" class ="form-button bg-blue-600 hover:bg-blue-700">Submit </button>
             </div>           

--- a/components/Forms/GrantForm.vue
+++ b/components/Forms/GrantForm.vue
@@ -1,12 +1,12 @@
 <template>
-    <div class="bg-[#e5e9ec] p-0 gap-0 border-0 rounded-md">
-        <VeeForm :initial-values="initValues" :validation-schema="schema" class= "w-[800px] max-h-[130vh] overflow-y-auto mx-4" @submit="submitGrant">
-            <div class = "flex flex-col gap-2 sm:text-left px-6 pt-6 pb-4 space-y-0">
+    <div class="bg-[#e5e9ec] rounded-md p-6">
+        <VeeForm :initial-values="initValues" :validation-schema="schema" class= "w-full max-w-3xl max-h-[80vh] overflow-y-auto mx-auto" @submit="submitGrant">
+            <div class = "px-6 pt-6 pb-5">
               <h1 class = "form-title"> Grant Information</h1>
             </div>
             <VeeField hidden name="id"></VeeField>
             <VeeField  hidden name="index"></VeeField> 
-            <div  class="grid grid-cols-2 gap-4 mb-3">
+            <div  class="grid grid-cols-2 gap-6 px-6 mb-4">
                 <h2 class="form-field-label">Grantor <span class = "text-red-500">*</span></h2>
                 <h2 class="form-field-label">Purpose <span class = "text-red-500">*</span></h2>                     
                 <VeeField autocomplete="off" v-slot="{field}" :disabled="viewOnly" name="grantorName" class="form-input focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]">
@@ -33,7 +33,7 @@
                 </div>                     
             </div>
             
-            <div class="grid grid-cols-2 gap-4 mb-3">
+            <div class="grid grid-cols-2 gap-6 px-6 mb-4">
                 <h2 class="form-field-label">Monetary Amount</h2>
                 <h2 class="form-field-label">Non-Monetary Amount</h2>
                 <VeeField autocomplete="off" :disabled="viewOnly" class="form-input focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]" name="monetaryAmount"/>
@@ -45,7 +45,7 @@
                     <VeeErrorMessage class="text-red-500"  name="nonMonetaryAmount" />
                 </div>
             </div>
-            <div class="grid grid-cols-2 gap-4 mb-3">
+            <div class="grid grid-cols-2 gap-6 px-6 mb-4">
                 <h2 class="form-field-label">Method <span class = "text-red-500">*</span></h2>
                 <h2 class="form-field-label">Status<span class = "text-red-500">*</span></h2>          
                 <VeeField v-slot="{field}" autocomplete="off" :disabled="viewOnly"name="method" class="form-input focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]">
@@ -69,7 +69,7 @@
                     <VeeErrorMessage class="text-red-500"  name="status" />
                 </div>
             </div>
-            <div class="grid grid-cols-2 gap-4 mb-5">
+            <div class="grid grid-cols-2 gap-6 px-6 mb-4">
                 <h2 class="form-field-label">Proposed Date</h2>
                 <h2 class="form-field-label">Received Date<span class = "text-red-500">*</span></h2>
                 <VeeField v-slot="{field}" autocomplete="off" :disabled="viewOnly" class="form-input focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]" name="proposedDate">
@@ -85,7 +85,7 @@
                     <VeeErrorMessage class="text-red-500" name="recievedDate" />
                 </div>
             </div>
-            <div class = "gap-4 mb-5">
+            <div class = "gap-4 px-6 mb-5">
                 <VeeField v-slot="{field}" name="reimburse" type="checkbox" :value="true" :unchecked-value="false">
                         <div class="flex items-center gap-2">
                             <input
@@ -99,10 +99,12 @@
                         </div>
                 </VeeField>
             </div>
-            <h2 class="form-field-label mb-2">Notes</h2>
-            <VeeField autocomplete="off" :disabled="viewOnly" v-slot="{field}" name="notes">
-                <textarea v-bind="field" class="form-field focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"></textarea>
-            </VeeField>
+            <div class="px-6 pb-6">
+                <h2 class="form-field-label mb-2">Notes</h2>
+                <VeeField autocomplete="off" :disabled="viewOnly" v-slot="{field}" name="notes">
+                    <textarea v-bind="field" class="form-field focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"></textarea>
+                </VeeField>
+            </div>
             <div class="flex justify-center gap-4 my-3">
                 <button class="form-button bg-gray-600 hover:bg-gray-700" @click="cancelSubmisison">Cancel</button>
                 <button v-if="!viewOnly" class ="form-button bg-blue-600 hover:bg-blue-700">Submit </button>

--- a/components/Forms/GrantorForm.vue
+++ b/components/Forms/GrantorForm.vue
@@ -1,18 +1,18 @@
 <template>
-    <div class="bg-[#e5e9ec] p-0 gap-0 border-0 rounded-md">
-        <VeeForm :initial-values="initValues" :validation-schema="schema" va @submit="submitGrantor" class= "w-[800px] max-h-[130vh] overflow-y-auto mx-4">
-            <div class = "flex flex-col gap-2 sm:text-left px-6 pt-6 pb-4 space-y-0">
+    <div class="bg-[#e5e9ec] rounded-md p-6">
+        <VeeForm :initial-values="initValues" :validation-schema="schema" va @submit="submitGrantor" class= "w-full max-w-3xl max-h-[80vh] overflow-y-auto mx-auto">
+            <div class = "px-6 pt-6 pb-5">
               <h1 class = "form-title"> Grantor Information</h1>
             </div>     
             <VeeField autocomplete="off" hidden name="id"></VeeField>
             <VeeField autocomplete="off" hidden name="index"></VeeField>  
-            <div class="grid gap-4 mb-2">
+            <div class="grid gap-6 px-6 mb-4">
                 <h2 class="form-field-label">Grantor <span class = "text-red-500">*</span></h2>
                 <VeeField autocomplete="off" :disabled="viewOnly" name="grantorName" class="form-input focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"></VeeField>
                 <VeeErrorMessage class="text-red-500" name= "grantorName" />
             </div>
 
-            <div class = "grid grid-cols-3 gap-4 mb-5">
+            <div class = "grid grid-cols-3 gap-4 px-6 mb-5">
                 <h2 class = "form-field-label"> Phone </h2>
                 <h2 class = "form-field-label"> Email </h2>
                 <h2 class = "form-field-label"> Communication Preference </h2>        
@@ -28,7 +28,7 @@
                 <VeeErrorMessage class="text-red-500" name="phone" />
                 <VeeErrorMessage class="text-red-500" name="email" />
             </div>
-            <div class = "mt-5 grid grid-cols-3 gap-4 my-8">
+            <div class = "grid grid-cols-3 gap-4 px-6 mb-5">
                 <h2 class = "form-field-label"> Organization </h2>
                 <h2 class = "form-field-label"> Address </h2>
                 <h2 class = "form-field-label"> Web Link </h2>
@@ -43,11 +43,13 @@
                 <VeeField autocomplete="off" :disabled="viewOnly" name="address" class="form-input focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"></VeeField> 
                 <VeeField autocomplete="off" :disabled="viewOnly" name="webLink"class="form-input focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"></VeeField>
             </div>
+            <div class="px-6 pb-6">
             <h2 class = "form-field-label mb-3"> Notes </h2>
-            <VeeField autocomplete="off" v-slot="{field}" :disabled="viewOnly" name="notes">
-                <textarea :disabled="viewOnly" v-bind="field" class="form-field focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"></textarea>
-            </VeeField>
-            <div class="flex justify-center gap-4 my-3">
+                <VeeField autocomplete="off" v-slot="{field}" :disabled="viewOnly" name="notes">
+                    <textarea :disabled="viewOnly" v-bind="field" class="form-field focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"></textarea>
+                </VeeField>
+            </div>
+            <div class="flex justify-center gap-4 pb-6">
                 <button @click="cancelSubmisison()" class ="form-button bg-gray-600 hover:bg-gray-700">Cancel</button>
                 <button v-if="!viewOnly" class ="form-button bg-blue-600 hover:bg-blue-700">Submit</button>
             </div>         

--- a/components/Tables/GrantTable.vue
+++ b/components/Tables/GrantTable.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="flex-1 p-8 ">
-        <div class = "bg-white rounded-lg shadow-lg overflow-hidden mx-auto">       
+        <div class = "bg-white rounded-lg shadow-lg overflow-x-auto mx-auto">       
             <table class="w-full">
                 <thead  class="bg-[#c5d0d8] sticky top-0 z-10">
                     <tr>

--- a/components/Tables/GrantorTable.vue
+++ b/components/Tables/GrantorTable.vue
@@ -1,13 +1,14 @@
 <template>
     <div class="flex-1 p-8 ">
         <button v-if="permissionLevel>1" :disabled="!isEnabled" @click="emailFunction(isChecked)" class ="disabled:bg-slate-300 rounded-md text-sm font-medium outline-none h-9 py-2 bg-blue-600 hover:bg-blue-700 text-white px-6 my-3 ">Email Grantors</button>
-        <div class = "bg-white rounded-lg shadow-lg overflow-hidden mx-auto">       
+        <div class = "bg-white rounded-lg shadow-lg overflow-x-auto mx-auto">       
             <table class="w-full">
-                <thead  class="bg-[#c5d0d8] sticky top-0 z-10">
+                <thead class="bg-[#c5d0d8] sticky top-0 z-10">
                     <tr>
                         <th class="px-4 py-3 text-left text-sm text-[#2d3e4d] border-b-2 border-[#a8b5bf] cursor-pointer transition-colors">
                             <div class="w-full flex gap-2">
                                 <span v-if="!activeSearch[0].active">Name</span>
+                 
                                 <button @click="toggleSearch(0)" v-if="!activeSearch[0].active"><FunnelIcon class="w-4 h-4"/></button>
                                 <div  v-else>
                                     <input autocomplete="off" v-model="searchInputs.name" @click.stop class="mt-2 px-2 py-1 border rounded"placeholder="Search Names"/>


### PR DESCRIPTION
the donations, donor, grant, grantor, and email form have been made responsive. this fixes the issues our project partner faced and allows them to navigate the forms easier until i finish refactoring the forms and standardizing the table components.

- there is a vertical scrollbar for the donations, donor, grant, grantor, and email forms
- when you change the website size vertically or horizontally, the form view will change size and you can view all form fields using the scrollbar
- zooming in or out of the website can change the form view sizes
- added a horizontal scroll onto the grant tables, which was previously missing

this is just a basic responsiveness fix before i refactor the forms by removing vee-validate and standardizing the table components. for example, right now, the grant form has issues with the content spacing, which is why its default form size is smaller. i am working on fixing these things while refactoring.