### PR TITLE
Harden donor API routes with session guards

### DIFF
--- a/server/api/donor/[id].delete.ts
+++ b/server/api/donor/[id].delete.ts
@@ -1,15 +1,10 @@
 import prisma from '~~/server/utils/prisma';
+import { requireSession } from "~~/server/utils/requireSession";
 
 export default defineEventHandler(async (event) => {  
     try {
+        await requireSession(event, 1);
         const id = await getRouterParam(event, 'id');
-        const body = await readBody(event);
-        if(body.permissionLevel < 1){
-            throw createError({
-                statusCode:401,
-                statusMessage:"User does not have permission to delete donors"
-            })
-        }
         const deletedDonor = await prisma.donor.delete({
             where: { id:id }
         });

--- a/server/api/donor/[id].get.ts
+++ b/server/api/donor/[id].get.ts
@@ -1,4 +1,5 @@
 import prisma from '~~/server/utils/prisma';
+import { requireSession } from "~~/server/utils/requireSession";
 
 ;
 
@@ -7,6 +8,7 @@ export default defineEventHandler(async (event) => {
 
     console.log("router reached")
     try {
+        await requireSession(event, 0);
         const id = getRouterParam(event, 'id');
 
         console.log("id found:", id);   

--- a/server/api/donor/[id].put.ts
+++ b/server/api/donor/[id].put.ts
@@ -1,17 +1,13 @@
 import prisma from '~~/server/utils/prisma';
+import { requireSession } from "~~/server/utils/requireSession";
 
 ;
 
 export default defineEventHandler(async (event) => {   
     try {
+        await requireSession(event, 1);
         const id = await getRouterParam(event, 'id');
         const body = await readBody(event);
-        if(body.permissionLevel < 1){
-            throw createError({
-                statusCode:401,
-                statusMessage:"User does not have permission to update donors"
-            })
-        }
         const updatedDonor = await prisma.donor.update({
             where: { id },
             data: {

--- a/server/api/donor/index.get.ts
+++ b/server/api/donor/index.get.ts
@@ -1,7 +1,9 @@
 import prisma from '~~/server/utils/prisma'
+import { requireSession } from "~~/server/utils/requireSession";
 
-export default defineEventHandler(async () =>{
+export default defineEventHandler(async (event) =>{
     try{
+        await requireSession(event, 0);
         const data = await prisma.donor.findMany({
             include:{
                 donations:{
@@ -34,4 +36,3 @@ export default defineEventHandler(async () =>{
         await prisma.$disconnect();
     }
 });
-

--- a/server/api/donor/index.post.ts
+++ b/server/api/donor/index.post.ts
@@ -1,14 +1,10 @@
 import prisma from '~~/server/utils/prisma'
+import { requireSession } from "~~/server/utils/requireSession";
 
 export default defineEventHandler(async (event) =>{
     try{
+        await requireSession(event, 1);
         const body = await readBody(event);
-        if(body.permissionLevel < 1){
-            throw createError({
-                statusCode:401,
-                statusMessage:"User does not have permission to create donors"
-            })
-        }
         const donor = await prisma.donor.create({
             data:{
                 name:       body.name,


### PR DESCRIPTION
This PR hardens donor endpoints by moving authorization enforcement to the server and removing reliance on client-provided permission values.

What changed

Added/standardized requireSession(...) checks on donor routes.
Removed fragile permission logic that depended on request body data.
Kept endpoint behavior intact while enforcing auth at the route boundary.

