### PR TITLE
Restrict user and email routes to privileged sessions

### DIFF
--- a/server/api/user/[id].delete.ts
+++ b/server/api/user/[id].delete.ts
@@ -1,16 +1,11 @@
 import prisma from '~~/server/utils/prisma'
+import { requireSession } from "~~/server/utils/requireSession";
 
 
 export default defineEventHandler(async (event) =>{
     try{
+        await requireSession(event, 2);
         const id = await getRouterParam(event, 'id');
-        const body = await readBody(event);
-        if(body.permissionLevel < 2){
-            throw createError({
-                statusCode:401,
-                statusMessage:"User does not have permission to delete users"
-            })
-        }
         const user = await prisma.user.delete({
             where:{
                 id:id

--- a/server/api/user/[id].delete.ts
+++ b/server/api/user/[id].delete.ts
@@ -4,8 +4,34 @@ import { requireSession } from "~~/server/utils/requireSession";
 
 export default defineEventHandler(async (event) =>{
     try{
-        await requireSession(event, 2);
-        const id = await getRouterParam(event, 'id');
+        const session = await requireSession(event, 2);
+        const id = getRouterParam(event, 'id');
+        if(!id){
+            throw createError({
+                statusCode: 400,
+                statusMessage: "User id is required"
+            });
+        }
+
+        const targetUser = await prisma.user.findUnique({
+            where: { id },
+            select: { id: true, permission: true }
+        });
+
+        if(!targetUser){
+            throw createError({
+                statusCode: 404,
+                statusMessage: "User not found"
+            });
+        }
+
+        if (session.user.permission === 2 && targetUser.permission > 1) {
+            throw createError({
+                statusCode: 403,
+                statusMessage: "Admins can only delete viewer/editor accounts"
+            });
+        }
+
         const user = await prisma.user.delete({
             where:{
                 id:id
@@ -24,7 +50,5 @@ export default defineEventHandler(async (event) =>{
             message: "Failed to delete user",
             error: error, 
         }
-    }finally{
-        await prisma.$disconnect();
     }
 });

--- a/server/api/user/[id].patch.ts
+++ b/server/api/user/[id].patch.ts
@@ -1,15 +1,11 @@
 import prisma from '~~/server/utils/prisma'
+import { requireSession } from "~~/server/utils/requireSession";
 
 export default defineEventHandler(async (event) =>{
     try{
+        await requireSession(event, 2);
         const id = await getRouterParam(event, 'id');
         const body = await readBody(event);
-        if(body.permissionLevel < 2){
-            throw createError({
-                statusCode:401,
-                statusMessage:"User does not have permission to edit users"
-            })
-        }
         const data = await prisma.user.update({
             where: {
                 id: id,

--- a/server/api/user/[id].patch.ts
+++ b/server/api/user/[id].patch.ts
@@ -13,6 +13,18 @@ export default defineEventHandler(async (event) =>{
         }
 
         const body = await readBody(event);
+        const bodyKeys = Object.keys(body ?? {});
+        const hasUnsupportedField = bodyKeys.some(
+            (key) => key !== "permission" && key !== "status"
+        );
+
+        if (hasUnsupportedField) {
+            throw createError({
+                statusCode: 400,
+                statusMessage: "Only permission and status can be updated"
+            });
+        }
+
         const targetUser = await prisma.user.findUnique({
             where: { id },
             select: { id: true, permission: true }
@@ -32,7 +44,7 @@ export default defineEventHandler(async (event) =>{
         if(nextPermission === undefined && nextStatus === undefined){
             throw createError({
                 statusCode: 400,
-                statusMessage: "Only permission or status can be updated"
+                statusMessage: "Permission or status is required"
             });
         }
 
@@ -52,14 +64,19 @@ export default defineEventHandler(async (event) =>{
             }
         }
 
+        const updateData: Record<string, unknown> = {};
+        if (nextPermission !== undefined) {
+            updateData.permission = nextPermission;
+        }
+        if (nextStatus !== undefined) {
+            updateData.status = nextStatus;
+        }
+
         const data = await prisma.user.update({
             where: {
                 id: id,
             },
-            data: {
-                ...(nextPermission !== undefined ? { permission: nextPermission } : {}),
-                ...(nextStatus !== undefined ? { status: nextStatus } : {}),
-            },
+            data: updateData,
         });
         return{
             success: true,

--- a/server/api/user/[id].patch.ts
+++ b/server/api/user/[id].patch.ts
@@ -3,18 +3,62 @@ import { requireSession } from "~~/server/utils/requireSession";
 
 export default defineEventHandler(async (event) =>{
     try{
-        await requireSession(event, 2);
-        const id = await getRouterParam(event, 'id');
+        const session = await requireSession(event, 2);
+        const id = getRouterParam(event, 'id');
+        if(!id){
+            throw createError({
+                statusCode: 400,
+                statusMessage: "User id is required"
+            });
+        }
+
         const body = await readBody(event);
+        const targetUser = await prisma.user.findUnique({
+            where: { id },
+            select: { id: true, permission: true }
+        });
+
+        if(!targetUser){
+            throw createError({
+                statusCode: 404,
+                statusMessage: "User not found"
+            });
+        }
+
+        const nextPermission =
+            body.permission !== undefined ? Number(body.permission) : undefined;
+        const nextStatus = body.status;
+
+        if(nextPermission === undefined && nextStatus === undefined){
+            throw createError({
+                statusCode: 400,
+                statusMessage: "Only permission or status can be updated"
+            });
+        }
+
+        if (session.user.permission === 2) {
+            if (targetUser.permission > 1) {
+                throw createError({
+                    statusCode: 403,
+                    statusMessage: "Admins can only modify viewer/editor accounts"
+                });
+            }
+
+            if (nextPermission !== undefined && nextPermission > 1) {
+                throw createError({
+                    statusCode: 403,
+                    statusMessage: "Admins can only set viewer/editor roles"
+                });
+            }
+        }
+
         const data = await prisma.user.update({
             where: {
                 id: id,
             },
             data: {
-                permission: body.permission,
-                status: body.status,
-                name:body.name,
-                email:body.email
+                ...(nextPermission !== undefined ? { permission: nextPermission } : {}),
+                ...(nextStatus !== undefined ? { status: nextStatus } : {}),
             },
         });
         return{
@@ -30,7 +74,5 @@ export default defineEventHandler(async (event) =>{
             message: "Failed to update user",
             error: error, 
         }
-    }finally{
-        await prisma.$disconnect();
     }
 });

--- a/server/api/user/index.get.ts
+++ b/server/api/user/index.get.ts
@@ -1,7 +1,9 @@
 import prisma from '~~/server/utils/prisma'
+import { requireSession } from "~~/server/utils/requireSession";
 
 export default defineEventHandler(async (event) =>{
     try{
+        await requireSession(event, 1);
         const data = await prisma.user.findMany();
         return{
             data:data,

--- a/server/api/user/index.get.ts
+++ b/server/api/user/index.get.ts
@@ -19,7 +19,5 @@ export default defineEventHandler(async (event) =>{
             error: error, 
             data:null
         }
-    } finally {
-        await prisma.$disconnect()
-    } 
+    }
 });

--- a/server/api/user/index.post.ts
+++ b/server/api/user/index.post.ts
@@ -1,15 +1,11 @@
 import prisma from '~~/server/utils/prisma'
+import { requireSession } from "~~/server/utils/requireSession";
 
 
 export default defineEventHandler(async (event) =>{
     try {
+        await requireSession(event, 3);
         const body = await readBody(event);
-        if(body.permissionLevel < 3){
-            throw createError({
-                statusCode:401,
-                statusMessage:"User does not have permission to create users"
-            })
-        }
         const user = await prisma.user.create({
         data:{
              name: body.name,

--- a/server/api/user/index.post.ts
+++ b/server/api/user/index.post.ts
@@ -28,8 +28,6 @@ export default defineEventHandler(async (event) =>{
             error: error, 
             data: null
         }
-    }finally{
-        await prisma.$disconnect();
     }
     
 });


### PR DESCRIPTION
This PR tightens access control for user-management and email endpoints to match mentor guidance and reduce exposure of privileged operations.

Added/updated requireSession(...) minimum permission checks for user and email routes.
Removed weaker patterns where applicable and centralized authorization at API entry points.
Aligned access policy with “editor and above” / admin-level expectations from review feedback.