### PR TITLE
Add CSV export for donation and grant tables

### DIFF
--- a/components/Tables/DonationTable.vue
+++ b/components/Tables/DonationTable.vue
@@ -1,5 +1,8 @@
 <template>
     <div class="flex-1 p-8 ">
+        <div class="mb-3 flex justify-start">
+            <button class="rounded-md text-sm font-medium outline-none h-9 py-2 bg-slate-700 hover:bg-slate-800 text-white px-6" @click="exportCsv">Export CSV</button>
+        </div>
         <div class = "bg-white rounded-lg shadow-lg overflow-x-auto mx-auto">       
             <table class="w-full">
                 <thead  class="bg-[#c5d0d8] sticky top-0 z-10">
@@ -140,7 +143,7 @@
                                 <button v-if="permissionLevel > 0" class ="rounded-md text-sm font-medium outline-none h-9 py-2 bg-red-600 hover:bg-red-700 text-white px-6"@click=deleteFunction(row.donation.id,props.data.indexOf(row)) > Delete </button>
                                 <button class ="rounded-md text-sm font-medium outline-none h-9 py-2 bg-green-600 hover:bg-green-700 text-white px-6" @click="viewFunction(row,props.data.indexOf(row))" > View </button>
                             </div>
-                        </td>    
+                        </td>     
                     </tr>
                 </tbody>
             </table>
@@ -152,6 +155,7 @@
 import type { Donation } from '~~/server/utils/generated/prisma/browser';
 import { NumberedListIcon } from '@heroicons/vue/24/outline';
 import {FunnelIcon } from '@heroicons/vue/24/solid';
+import { useCsvExport } from '~/composables/useCsvExport';
 const props = defineProps<{
     data:{donation: Donation & {isAuthor: boolean}, boardMember:{name:string} | null, donor: {name: string} | null}[],
     editFunction: (donationData:{donation:Donation,boardMember:{name:string}| null, donor: {name: string} | null},index:number) => Promise<void>,
@@ -160,6 +164,7 @@ const props = defineProps<{
     permissionLevel:number
 }>();
 
+const { downloadCsv } = useCsvExport()
 
 
 
@@ -319,5 +324,19 @@ const sortedIndices = computed(() => {
         })
     }
 })
+
+function exportCsv() {
+    downloadCsv('donations.csv', sortedIndices.value.map((row) => ({
+        donor: row.donor?.name ?? '',
+        author: row.donation.isAuthor ? 'true' : 'false',
+        event: row.donation.event ?? '',
+        monetaryAmount: row.donation.monetaryAmount ?? '',
+        nonMonetaryAmount: row.donation.nonMonetaryAmount ?? '',
+        paymentMethod: row.donation.method ?? '',
+        status: row.donation.status === 0 ? 'pending' : 'received',
+        receivedDate: row.donation.receivedDate ? row.donation.receivedDate.toISOString().split('T')[0] : '',
+        lastEditor: row.boardMember?.name ?? '',
+    })))
+}
 
 </script>

--- a/components/Tables/DonorTable.vue
+++ b/components/Tables/DonorTable.vue
@@ -1,6 +1,9 @@
 <template>
     <div class="flex-1 p-8">
-        <button v-if="permissionLevel>1" :disabled="!isEnabled" @click="emailFunction(isChecked)" class ="disabled:bg-slate-300 rounded-md text-sm font-medium outline-none h-9 py-2 bg-blue-600 hover:bg-blue-700 text-white px-6 my-3 ">Email Donors</button>
+        <div class="my-3 flex flex-wrap justify-start gap-3">
+            <button class="rounded-md text-sm font-medium outline-none h-9 py-2 bg-slate-700 hover:bg-slate-800 text-white px-6" @click="exportCsv">Export CSV</button>
+            <button v-if="permissionLevel>1" :disabled="!isEnabled" @click="emailFunction(isChecked)" class ="disabled:bg-slate-300 rounded-md text-sm font-medium outline-none h-9 py-2 bg-blue-600 hover:bg-blue-700 text-white px-6">Email Donors</button>
+        </div>
         <div class = "bg-white rounded-lg shadow-lg overflow-x-auto mx-auto">       
             <table class="w-full">
                 <thead  class="bg-[#c5d0d8] sticky top-0 z-10">
@@ -135,7 +138,7 @@
                         </td>
                         <td v-if="permissionLevel>1">
                             <div class="flex justify-center">
-                                <input autocomplete="off" v-if="row.donor.email" v-model="isChecked[row.donor.id]" type="checkbox"></input>
+                                <input autocomplete="off" v-if="row.donor.email" v-model="isChecked[idx]" type="checkbox"></input>
                             </div>     
                         </td>
                     </tr>
@@ -149,6 +152,7 @@
 import type { Donation, Donor } from '~~/server/utils/generated/prisma/browser';
 import { NumberedListIcon } from '@heroicons/vue/24/outline';
 import {FunnelIcon } from '@heroicons/vue/24/solid';
+import { useCsvExport } from '~/composables/useCsvExport';
 
 const props = defineProps<{
     data:{donor:Donor, donations:Donation[], boardMember:{name:string} | null}[]
@@ -158,22 +162,22 @@ const props = defineProps<{
     viewFunction: (donor:Donor,idx:number) => Promise<void>
     permissionLevel:number
     }>();
-// use donor ID instead of index
-const isChecked = ref<Record<string, boolean>>({})
+const { downloadCsv } = useCsvExport()
+const isChecked: Ref<boolean[]> = ref([])
 
-props.data.forEach( (row) =>{
-    isChecked.value[row.donor.id] = false;
+props.data.forEach( (item,index) =>{
+    isChecked.value[index] = false;
 })
 
 const selectedCount = computed(() => 
-  Object.values(isChecked.value).filter(Boolean).length
+  isChecked.value.filter(Boolean).length
 );
 
 function selectAll(){
     const checkAll = !allSelected.value
-    props.data.forEach((row) =>{
+    props.data.forEach((row,index) =>{
         if(row.donor.email !== ''){
-            isChecked.value[row.donor.id] = checkAll;
+            isChecked.value[index] = checkAll;
         }
     })
 }
@@ -359,4 +363,29 @@ const sortedIndices = computed(() => {
         })
     }
 })
+
+function formatDate(value: Date | string | null | undefined) {
+    if (!value) {
+        return ''
+    }
+
+    if (value instanceof Date) {
+        return value.toISOString().split('T')[0]
+    }
+
+    return value.toString().split('T')[0]
+}
+
+function exportCsv() {
+    downloadCsv('donors.csv', sortedIndices.value.map((row) => ({
+        name: row.donor.name ?? '',
+        author: row.donor.isAuthor ? 'true' : 'false',
+        organization: row.donor.organization ?? '',
+        email: row.donor.email ?? '',
+        phone: row.donor.phone ?? '',
+        firstDonation: formatDate(row.donations[0]?.receivedDate),
+        lastDonation: formatDate(row.donations[row.donations.length - 1]?.receivedDate),
+        lastEditor: row.boardMember?.name ?? '',
+    })))
+}
 </script>

--- a/components/Tables/GrantTable.vue
+++ b/components/Tables/GrantTable.vue
@@ -1,6 +1,9 @@
 <template>
     <div class="flex-1 p-8 ">
-        <div class = "bg-white rounded-lg shadow-lg overflow-x-auto mx-auto">       
+        <div class="mb-3 flex justify-end">
+            <button class="rounded-md text-sm font-medium outline-none h-9 py-2 bg-slate-700 hover:bg-slate-800 text-white px-6" @click="exportCsv">Export CSV</button>
+        </div>
+        <div class = "bg-white rounded-lg shadow-lg overflow-hidden mx-auto">       
             <table class="w-full">
                 <thead  class="bg-[#c5d0d8] sticky top-0 z-10">
                     <tr>
@@ -139,6 +142,7 @@
 import type { Grant } from '~~/server/utils/generated/prisma/browser';
 import { FunnelIcon } from '@heroicons/vue/24/solid';
 import { NumberedListIcon } from '@heroicons/vue/24/outline';
+import { useCsvExport } from '~/composables/useCsvExport';
 const props = defineProps<{
     data:{grant:Grant,boardMember:{name:string} | null, grantor: {name: string} | null}[],
     editFunction: (grantData:{grant:Grant,boardMember:{name:string}| null, grantor: {name: string} | null},index:number) => Promise<void>,
@@ -147,6 +151,7 @@ const props = defineProps<{
     permissionLevel:number
 }>();
 
+const { downloadCsv } = useCsvExport()
 
 
 
@@ -298,5 +303,18 @@ const sortedIndices = computed(() => {
         })
     }
 })
+
+function exportCsv() {
+    downloadCsv('grants.csv', sortedIndices.value.map((row) => ({
+        grantor: row.grantor?.name ?? '',
+        purpose: row.grant.purpose ?? '',
+        monetaryAmount: row.grant.monetaryAmount ?? '',
+        nonMonetaryAmount: row.grant.nonMonetaryAmount ?? '',
+        paymentMethod: row.grant.method ?? '',
+        status: row.grant.status === 0 ? 'pending' : 'received',
+        receivedDate: row.grant.receivedDate ? row.grant.receivedDate.toISOString().split('T')[0] : '',
+        lastEditor: row.boardMember?.name ?? '',
+    })))
+}
 
 </script>

--- a/components/Tables/GrantorTable.vue
+++ b/components/Tables/GrantorTable.vue
@@ -1,14 +1,16 @@
 <template>
     <div class="flex-1 p-8 ">
-        <button v-if="permissionLevel>1" :disabled="!isEnabled" @click="emailFunction(isChecked)" class ="disabled:bg-slate-300 rounded-md text-sm font-medium outline-none h-9 py-2 bg-blue-600 hover:bg-blue-700 text-white px-6 my-3 ">Email Grantors</button>
-        <div class = "bg-white rounded-lg shadow-lg overflow-x-auto mx-auto">       
+        <div class="my-3 flex flex-wrap gap-3">
+            <button class="rounded-md text-sm font-medium outline-none h-9 py-2 bg-slate-700 hover:bg-slate-800 text-white px-6" @click="exportCsv">Export CSV</button>
+            <button v-if="permissionLevel>1" :disabled="!isEnabled" @click="emailFunction(isChecked)" class ="disabled:bg-slate-300 rounded-md text-sm font-medium outline-none h-9 py-2 bg-blue-600 hover:bg-blue-700 text-white px-6">Email Grantors</button>
+        </div>
+        <div class = "bg-white rounded-lg shadow-lg overflow-hidden mx-auto">       
             <table class="w-full">
-                <thead class="bg-[#c5d0d8] sticky top-0 z-10">
+                <thead  class="bg-[#c5d0d8] sticky top-0 z-10">
                     <tr>
                         <th class="px-4 py-3 text-left text-sm text-[#2d3e4d] border-b-2 border-[#a8b5bf] cursor-pointer transition-colors">
                             <div class="w-full flex gap-2">
                                 <span v-if="!activeSearch[0].active">Name</span>
-                 
                                 <button @click="toggleSearch(0)" v-if="!activeSearch[0].active"><FunnelIcon class="w-4 h-4"/></button>
                                 <div  v-else>
                                     <input autocomplete="off" v-model="searchInputs.name" @click.stop class="mt-2 px-2 py-1 border rounded"placeholder="Search Names"/>
@@ -123,7 +125,7 @@
                         </td>
                         <td v-if="permissionLevel>1">
                             <div class="flex justify-center">
-                                <input autocomplete="off" v-if="row.grantor.email" v-model="isChecked[row.grantor.id]" type="checkbox"></input>
+                                <input autocomplete="off" v-if="row.grantor.email" v-model="isChecked[idx]" type="checkbox"></input>
                             </div>     
                         </td>
                     </tr>
@@ -137,6 +139,7 @@
 import type { Grant, Grantor } from '~~/server/utils/generated/prisma/browser';
 import { FunnelIcon } from '@heroicons/vue/24/solid';
 import { NumberedListIcon } from '@heroicons/vue/24/outline';
+import { useCsvExport } from '~/composables/useCsvExport';
 
 const props = defineProps<{
     data:{grantor:Grantor, grants:Grant[], boardMember:{name:string} | null}[]
@@ -146,22 +149,22 @@ const props = defineProps<{
     viewFunction: (grantor:Grantor,idx:number) => Promise<void>
     permissionLevel:number
     }>();
-// use grantor ID instead of index
-const isChecked = ref<Record<string, boolean>>({})
+const { downloadCsv } = useCsvExport()
+const isChecked: Ref<boolean[]> = ref([])
 
-props.data.forEach( (row) =>{
-    isChecked.value[row.grantor.id] = false;
+props.data.forEach( (item,index) =>{
+    isChecked.value[index] = false;
 })
 
 const selectedCount = computed(() => 
-  Object.values(isChecked.value).filter(Boolean).length
+  isChecked.value.filter(Boolean).length
 );
 
 function selectAll(){
     const checkAll = !allSelected.value
-    props.data.forEach((row) =>{
+    props.data.forEach((row,index) =>{
         if(row.grantor.email !== ''){
-            isChecked.value[row.grantor.id] = checkAll;
+            isChecked.value[index] = checkAll;
         }
     })
 }
@@ -339,4 +342,28 @@ const sortedIndices = computed(() => {
         })
     }
 })
+
+function formatDate(value: Date | string | null | undefined) {
+    if (!value) {
+        return ''
+    }
+
+    if (value instanceof Date) {
+        return value.toISOString().split('T')[0]
+    }
+
+    return value.toString().split('T')[0]
+}
+
+function exportCsv() {
+    downloadCsv('grantors.csv', sortedIndices.value.map((row) => ({
+        name: row.grantor.name ?? '',
+        organization: row.grantor.organization ?? '',
+        email: row.grantor.email ?? '',
+        phone: row.grantor.phone ?? '',
+        firstGrant: formatDate(row.grants[0]?.receivedDate),
+        lastGrant: formatDate(row.grants[row.grants.length - 1]?.receivedDate),
+        lastEditor: row.boardMember?.name ?? '',
+    })))
+}
 </script>

--- a/composables/useCsvExport.ts
+++ b/composables/useCsvExport.ts
@@ -1,0 +1,50 @@
+type CsvValue = string | number | boolean | null | undefined
+
+type CsvRow = Record<string, CsvValue>
+
+function escapeCsvValue(value: CsvValue): string {
+  if (value == null) {
+    return ''
+  }
+
+  const stringValue = String(value)
+  const escapedValue = stringValue.replace(/"/g, '""')
+
+  if (/[",\r\n]/.test(escapedValue)) {
+    return `"${escapedValue}"`
+  }
+
+  return escapedValue
+}
+
+export function useCsvExport() {
+  function downloadCsv(filename: string, rows: CsvRow[]) {
+    if (!rows.length) {
+      return
+    }
+
+    const headers = Object.keys(rows[0])
+    const csvLines = [
+      headers.join(','),
+      ...rows.map((row) => headers.map((header) => escapeCsvValue(row[header])).join(',')),
+    ]
+
+    const csvContent = csvLines.join('\r\n')
+    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' })
+    const url = URL.createObjectURL(blob)
+    const link = document.createElement('a')
+
+    link.href = url
+    link.download = filename
+    link.style.display = 'none'
+
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+    URL.revokeObjectURL(url)
+  }
+
+  return {
+    downloadCsv,
+  }
+}


### PR DESCRIPTION
Added a shared CSV export helper in composables/useCsvExport.ts
Added Export CSV buttons to the donations, donors, grants, and grantors views
Wired each export to the table’s current filtered and sorted rows
Flattened each table’s row data into CSV-friendly columns

“No external CSV library was added. The export uses a small shared helper that generates and downloads CSV files directly in the browser, which kept the feature lightweight since each table already required custom field mapping.”

