### PR TITLE
overide nuxt ui background styling

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,7 +1,14 @@
 @import "tailwindcss";
 @import "@nuxt/ui";
 
-@layer components{
+@layer base {
+    body {
+        background-color: white !important;
+        color: #111827 !important;
+    }
+}
+
+@layer components {
     .form-field-label{
         @apply text-sm leading-none font-medium text-[#5a6a77] mt-3;
     }


### PR DESCRIPTION
This simply overrides Nuxt UI's background. For me at least, I think that was the primary place that Nuxt UI was interfering, especially since most of our things have already predefined CSS styling (which overrides Nuxt UI).